### PR TITLE
Add support for line and polygon stipples

### DIFF
--- a/Primer.md
+++ b/Primer.md
@@ -673,6 +673,7 @@ Special features:
 
 - Fill rectangle
 - Legacy smoothing
+- Polygon and line stipples
 - Depth bias
 - Multisampling
 - Conservative rasterization
@@ -684,6 +685,8 @@ struct DkSampleLocation;
 void dkCmdBufBindRasterizerState(DkCmdBuf obj, DkRasterizerState const* state);
 void dkCmdBufSetPointSize(DkCmdBuf obj, float size);
 void dkCmdBufSetLineWidth(DkCmdBuf obj, float width);
+void dkCmdBufSetLineStipple(DkCmdBuf obj, bool enable, uint32_t factor, uint16_t pattern);
+void dkCmdBufSetPolygonStipple(DkCmdBuf obj, uint32_t const pattern[32]);
 void dkCmdBufSetConservativeRasterEnable(DkCmdBuf obj, bool enable);
 void dkCmdBufSetConservativeRasterDilate(DkCmdBuf obj, float dilate);
 void dkCmdBufSetSubpixelPrecisionBias(DkCmdBuf obj, uint32_t xbits, uint32_t ybits);
@@ -699,6 +702,8 @@ void dkMultisampleStateSetLocations(DkMultisampleState* obj, DkSampleLocation co
 - [VkPipelineRasterizationStateCreateInfo](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/VkPipelineRasterizationStateCreateInfo.html)
 - [NV_fill_rectangle](https://www.khronos.org/registry/OpenGL/extensions/NV/NV_fill_rectangle.txt)
 - [vkCmdSetDepthBias](https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCmdSetDepthBias.html)
+- [glLineStipple](https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glLineStipple.xml)
+- [glPolygonStipple](https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glPolygonStipple.xml)
 - [Multisampling](https://www.khronos.org/opengl/wiki/Multisampling)
 	- [EXT_raster_multisample](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_raster_multisample.txt) (General target-independent rasterization)
 	- [NV_framebuffer_mixed_samples](https://www.khronos.org/registry/OpenGL/extensions/NV/NV_framebuffer_mixed_samples.txt) (Higher MSAA mode for depth buffer, which afterwards results in coverage reduction)

--- a/include/deko3d.h
+++ b/include/deko3d.h
@@ -1219,6 +1219,8 @@ void dkCmdBufSetScissors(DkCmdBuf obj, uint32_t firstId, DkScissor const scissor
 void dkCmdBufSetDepthBias(DkCmdBuf obj, float constantFactor, float clamp, float slopeFactor);
 void dkCmdBufSetPointSize(DkCmdBuf obj, float size);
 void dkCmdBufSetLineWidth(DkCmdBuf obj, float width);
+void dkCmdBufSetLineStipple(DkCmdBuf obj, bool enable, uint32_t factor, uint16_t pattern);
+void dkCmdBufSetPolygonStipple(DkCmdBuf obj, uint32_t const pattern[32]);
 void dkCmdBufSetConservativeRasterEnable(DkCmdBuf obj, bool enable);
 void dkCmdBufSetConservativeRasterDilate(DkCmdBuf obj, float dilate);
 void dkCmdBufSetSampleMask(DkCmdBuf obj, uint32_t mask);

--- a/include/deko3d.hpp
+++ b/include/deko3d.hpp
@@ -207,6 +207,8 @@ namespace dk
 		void setDepthBias(float constantFactor, float clamp, float slopeFactor);
 		void setPointSize(float size);
 		void setLineWidth(float width);
+		void setLineStipple(bool enable, uint32_t factor, uint16_t pattern);
+		void setPolygonStipple(uint32_t const pattern[32]);
 		void setConservativeRasterEnable(bool enable);
 		void setConservativeRasterDilate(float dilate);
 		void setSampleMask(uint32_t mask);
@@ -787,6 +789,16 @@ namespace dk
 	inline void CmdBuf::setLineWidth(float width)
 	{
 		::dkCmdBufSetLineWidth(*this, width);
+	}
+
+	inline void CmdBuf::setLineStipple(bool enable, uint32_t factor, uint16_t pattern)
+	{
+		::dkCmdBufSetLineStipple(*this, enable, factor, pattern);
+	}
+
+	inline void CmdBuf::setPolygonStipple(uint32_t const pattern[32])
+	{
+		::dkCmdBufSetPolygonStipple(*this, pattern);
 	}
 
 	inline void CmdBuf::setConservativeRasterEnable(bool enable)

--- a/source/maxwell/engine_3d.def
+++ b/source/maxwell/engine_3d.def
@@ -551,11 +551,17 @@ engine _3D 0xB197;
 	2 High;
 );
 
+0x59B LineStippleEnable bool;
+0x5A0 LineStipplePattern;
 0x5A1 ProvokingVertexLast bool;
+
+0x5A3 PolygonStippleEnable bool;
 
 0x5AA Unknown5aa;
 
 0x5AD Unknown5ad;
+
+0x5C0 PolygonStipplePattern array[32];
 
 0x5E5 Unknown5e5;
 

--- a/source/maxwell/gpu_3d_state.cpp
+++ b/source/maxwell/gpu_3d_state.cpp
@@ -175,6 +175,38 @@ void dkCmdBufSetLineWidth(DkCmdBuf obj, float width)
 	w << Cmd(3D, LineWidthSmooth{}, width, width);
 }
 
+void dkCmdBufSetLineStipple(DkCmdBuf obj, bool enable, uint32_t factor, uint16_t pattern)
+{
+	DK_ENTRYPOINT(obj);
+	DK_DEBUG_BAD_INPUT(factor < 1 || factor > 256);
+
+	CmdBufWriter w{obj};
+	w.reserve(3);
+
+	w << CmdInline(3D, LineStippleEnable{}, enable);
+	if (enable)
+	{
+		uint32_t packed = (pattern << 8) | ((uint8_t)factor - 1);
+		w << Cmd(3D, LineStipplePattern{}, packed);
+	}
+}
+
+void dkCmdBufSetPolygonStipple(DkCmdBuf obj, uint32_t const pattern[32])
+{
+	DK_ENTRYPOINT(obj);
+
+	CmdBufWriter w{obj};
+	w.reserve(34);
+
+	if (!pattern)
+		w << CmdInline(3D, PolygonStippleEnable{}, 0);
+	else
+	{
+		w << CmdList<1>{ MakeCmdHeader(Increasing, 32, Subchannel3D, Engine3D::PolygonStipplePattern{}) };
+		w.addRawData(pattern, 32 * sizeof(u32));
+	}
+}
+
 void dkCmdBufSetConservativeRasterEnable(DkCmdBuf obj, bool enable)
 {
 	DK_ENTRYPOINT(obj);


### PR DESCRIPTION
Add support for [polygon stipples](https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glPolygonStipple.xml) and [line stipples](https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glLineStipple.xml), adding `dkCmdBufSetPolygonStipple` and `dkCmdBufSetLineStipple` respectively.

Line stipples look like this: 
![imagen](https://user-images.githubusercontent.com/26564870/84082402-26e67180-a9b6-11ea-9a83-100e3fe2297e.png)
