### PR TITLE
Add DkProvokingVertex: Allow the provoking vertex to be the first in the primitive

### DIFF
--- a/include/deko3d.h
+++ b/include/deko3d.h
@@ -764,6 +764,12 @@ typedef enum DkFrontFace
 	DkFrontFace_CCW = 1,
 } DkFrontFace;
 
+typedef enum DkProvokingVertex
+{
+	DkProvokingVertex_First = 0,
+	DkProvokingVertex_Last = 1,
+} DkProvokingVertex;
+
 typedef struct DkRasterizerState
 {
 	uint32_t rasterizerEnable : 1;
@@ -773,6 +779,7 @@ typedef struct DkRasterizerState
 	DkPolygonMode polygonModeBack : 2;
 	DkFace cullMode : 2;
 	DkFrontFace frontFace : 1;
+	DkProvokingVertex provokingVertex : 1;
 	uint32_t polygonSmoothEnableMask : 3;
 	uint32_t depthBiasEnableMask : 3;
 } DkRasterizerState;
@@ -786,6 +793,7 @@ DK_CONSTEXPR void dkRasterizerStateDefaults(DkRasterizerState* state)
 	state->polygonModeBack = DkPolygonMode_Fill;
 	state->cullMode = DkFace_Back;
 	state->frontFace = DkFrontFace_CCW;
+	state->provokingVertex = DkProvokingVertex_Last;
 	state->polygonSmoothEnableMask = 0;
 	state->depthBiasEnableMask = 0;
 }

--- a/include/deko3d.hpp
+++ b/include/deko3d.hpp
@@ -478,6 +478,7 @@ namespace dk
 		RasterizerState& setPolygonModeBack(DkPolygonMode mode) { this->polygonModeBack = mode; return *this; }
 		RasterizerState& setCullMode(DkFace cullMode) { this->cullMode = cullMode; return *this; }
 		RasterizerState& setFrontFace(DkFrontFace frontFace) { this->frontFace = frontFace; return *this; }
+		RasterizerState& setProvokingVertex(DkProvokingVertex provokingVertex) { this->provokingVertex = provokingVertex; return *this; }
 		RasterizerState& setPolygonSmoothEnable(bool enable) { this->polygonSmoothEnableMask = enable ? DkPolygonFlag_All : 0; return *this; }
 		RasterizerState& setPolygonSmoothEnableMask(uint32_t mask) { this->polygonSmoothEnableMask = mask; return *this; }
 		RasterizerState& setDepthBiasEnable(bool enable) { this->depthBiasEnableMask = enable ? DkPolygonFlag_All : 0; return *this; }

--- a/source/maxwell/gpu_3d_state.cpp
+++ b/source/maxwell/gpu_3d_state.cpp
@@ -33,7 +33,7 @@ void dkCmdBufBindRasterizerState(DkCmdBuf obj, DkRasterizerState const* state)
 	DK_ENTRYPOINT(obj);
 	DK_DEBUG_NON_NULL(state);
 	CmdBufWriter w{obj};
-	w.reserve(14);
+	w.reserve(15);
 
 	w << CmdInline(3D, RasterizerEnable{}, state->rasterizerEnable);
 	if (!state->rasterizerEnable)
@@ -63,6 +63,8 @@ void dkCmdBufBindRasterizerState(DkCmdBuf obj, DkRasterizerState const* state)
 
 	static const uint16_t frontFaces[] = { E::SetFrontFace::CW, E::SetFrontFace::CCW };
 	w << CmdInline(3D, SetFrontFace{}, frontFaces[state->frontFace]);
+
+	w << CmdInline(3D, ProvokingVertexLast{}, state->provokingVertex == DkProvokingVertex_First ? 0 : 1);
 
 	w << CmdInline(3D, PointSmoothEnable{},        (state->polygonSmoothEnableMask & DkPolygonFlag_Point) != 0);
 	w << CmdInline(3D, LineSmoothEnable{},         (state->polygonSmoothEnableMask & DkPolygonFlag_Line) != 0);


### PR DESCRIPTION
Tested with flat shading. This might have to be retested when transform feedback is implemented, unless the hardware takes care of it for us (it probably does).