### PR TITLE
Report counters and gpu timestamp

### DIFF
--- a/Primer.md
+++ b/Primer.md
@@ -558,6 +558,20 @@ void dkCmdBufTiledCacheOp(DkCmdBuf obj, DkTiledCacheOp op);
 void dkCmdBufSetTileSize(DkCmdBuf obj, uint32_t width, uint32_t height);
 ```
 
+### Counters
+
+```c
+void dkCmdBufReportCounter(DkCmdBuf obj, DkCounter type, DkGpuAddr addr);
+void dkCmdBufReportValue(DkCmdBuf obj, uint32_t value, DkGpuAddr addr);
+void dkCmdBufResetCounter(DkCmdBuf obj, DkCounter type);
+```
+
+For all counter types except `DkCounter_ZcullStats`, a report consists of two consecutive 64-bit values, the first one being the specified counter, and the second the timestamp at which the report was done.
+`dkCmdBufReportValue` will write the specified value as well as the timestamp.
+In the case of `DkCounter_ZcullStats`, it reports four 32-bit values relating to ZCull operations. `dkCmdBufResetCounter` resets the specified counter to 0. Some counters cannot be reset.
+
+Note that all three functions entail a tiled cache flush.
+
 ### Command capture and replay
 
 ```c

--- a/Primer.md
+++ b/Primer.md
@@ -183,6 +183,8 @@ struct DkDeviceMaker
 void dkDeviceMakerDefaults(DkDeviceMaker* maker);
 DkDevice dkDeviceCreate(DkDeviceMaker const* maker);
 void dkDeviceDestroy(DkDevice obj);
+uint64_t dkDeviceGetCurrentTimestamp(DkDevice obj);
+uint64_t dkDeviceGetCurrentTimestampInNs(DkDevice obj);
 ```
 
 `DkDevice` is the root object from which most other deko3d objects can be traced back. It represents the GPU device with a private virtual GPU address space, and provides optional mechanisms for customizing the error handling or memory allocation behavior.
@@ -217,6 +219,8 @@ By default if memory allocation callbacks are not provided, deko3d uses the stan
 
 `gl_FragCoord` in fragment shaders obeys the device origin mode when it comes to the Y axis and has pixel centers at half-integers, *with GLSL layout qualifiers having absolutely no effect*.
 Please note that regardless of the Origin setting, the clip space Y axis points *up* like in OpenGL. Clip space X and Y are both in the range [-1, 1] as well.
+
+The current GPU tick can be queried without queuing a command buffer with `dkDeviceGetCurrentTimestamp`, and converted back and forth to nanoseconds using `dkNsToTimestamp`/`dkTimestampToNs`. See also [counters](#counters).
 
 ### Memory Blocks (`DkMemBlock`)
 

--- a/include/deko3d.h
+++ b/include/deko3d.h
@@ -221,6 +221,27 @@ typedef enum DkPipelinePos
 	DkPipelinePos_Bottom     = 2,
 } DkPipelinePos;
 
+typedef enum DkCounter
+{
+    DkCounter_TimestampPipelineTop               = 0,
+    DkCounter_Timestamp                          = 1,
+    DkCounter_SamplesPassed                      = 2,
+    DkCounter_ZcullStats                         = 3,
+    DkCounter_InputVertices                      = 4,
+    DkCounter_InputPrimitives                    = 5,
+    DkCounter_VertexShaderInvocations            = 6,
+    DkCounter_TessControlShaderInvocations       = 7,
+    DkCounter_TessEvaluationShaderInvocations    = 8,
+    DkCounter_GeometryShaderInvocations          = 9,
+    DkCounter_FragmentShaderInvocations          = 10,
+    DkCounter_TessEvaluationShaderPrimitives     = 11,
+    DkCounter_GeometryShaderPrimitives           = 12,
+    DkCounter_ClipperInputPrimitives             = 13,
+    DkCounter_ClipperOutputPrimitives            = 14,
+    DkCounter_PrimitivesGenerated                = 15,
+    DkCounter_TransformFeedbackPrimitivesWritten = 16,
+} DkCounter;
+
 typedef struct DkCmdBufMaker
 {
 	DkDevice device;
@@ -1292,6 +1313,9 @@ void dkCmdBufBlitImage(DkCmdBuf obj, DkImageView const* srcView, DkImageRect con
 void dkCmdBufResolveImage(DkCmdBuf obj, DkImageView const* srcView, DkImageView const* dstView);
 void dkCmdBufCopyBufferToImage(DkCmdBuf obj, DkCopyBuf const* src, DkImageView const* dstView, DkImageRect const* dstRect, uint32_t flags);
 void dkCmdBufCopyImageToBuffer(DkCmdBuf obj, DkImageView const* srcView, DkImageRect const* srcRect, DkCopyBuf const* dst, uint32_t flags);
+void dkCmdBufReportCounter(DkCmdBuf obj, DkCounter type, DkGpuAddr addr);
+void dkCmdBufReportValue(DkCmdBuf obj, uint32_t value, DkGpuAddr addr);
+void dkCmdBufResetCounter(DkCmdBuf obj, DkCounter type);
 
 DkQueue dkQueueCreate(DkQueueMaker const* maker);
 void dkQueueDestroy(DkQueue obj);

--- a/include/deko3d.h
+++ b/include/deko3d.h
@@ -1225,6 +1225,10 @@ extern "C" {
 
 DkDevice dkDeviceCreate(DkDeviceMaker const* maker);
 void dkDeviceDestroy(DkDevice obj);
+uint64_t dkDeviceGetCurrentTimestamp(DkDevice obj);
+uint64_t dkDeviceGetCurrentTimestampInNs(DkDevice obj);
+DK_CONSTEXPR uint64_t dkTimestampToNs(uint64_t ts);
+DK_CONSTEXPR uint64_t dkNsToTimestamp(uint64_t ns);
 
 DkMemBlock dkMemBlockCreate(DkMemBlockMaker const* maker);
 void dkMemBlockDestroy(DkMemBlock obj);
@@ -1350,6 +1354,14 @@ void dkSwapchainDestroy(DkSwapchain obj);
 void dkSwapchainAcquireImage(DkSwapchain obj, int* imageSlot, DkFence* fence);
 void dkSwapchainSetCrop(DkSwapchain obj, int32_t left, int32_t top, int32_t right, int32_t bottom);
 void dkSwapchainSetSwapInterval(DkSwapchain obj, uint32_t interval);
+
+DK_CONSTEXPR uint64_t dkTimestampToNs(uint64_t ts) {
+	return (ts * 625) / 384;
+}
+
+DK_CONSTEXPR uint64_t dkNsToTimestamp(uint64_t ns) {
+	return (ns * 384) / 625;
+}
 
 static inline void dkCmdBufBindUniformBuffer(DkCmdBuf obj, DkStage stage, uint32_t id, DkGpuAddr bufAddr, uint32_t bufSize)
 {

--- a/include/deko3d.hpp
+++ b/include/deko3d.hpp
@@ -253,6 +253,9 @@ namespace dk
 		void resolveImage(DkImageView const& srcView, DkImageView const& dstView);
 		void copyBufferToImage(DkCopyBuf const& src, DkImageView const& dstView, DkImageRect const& dstRect, uint32_t flags = 0);
 		void copyImageToBuffer(DkImageView const& srcView, DkImageRect const& srcRect, DkCopyBuf const& dst, uint32_t flags = 0);
+		void reportCounter(DkCounter type, DkGpuAddr addr);
+		void reportValue(uint32_t value, DkGpuAddr addr);
+		void resetCounter(DkCounter type);
 	};
 
 	struct Queue : public detail::Handle<::DkQueue>
@@ -1008,6 +1011,21 @@ namespace dk
 	inline void CmdBuf::copyImageToBuffer(DkImageView const& srcView, DkImageRect const& srcRect, DkCopyBuf const& dst, uint32_t flags)
 	{
 		::dkCmdBufCopyImageToBuffer(*this, &srcView, &srcRect, &dst, flags);
+	}
+
+	inline void CmdBuf::reportCounter(DkCounter type, DkGpuAddr addr)
+	{
+		return ::dkCmdBufReportCounter(*this, type, addr);
+	}
+
+	inline void CmdBuf::reportValue(uint32_t value, DkGpuAddr addr)
+	{
+		return ::dkCmdBufReportValue(*this, value, addr);
+	}
+
+	inline void CmdBuf::resetCounter(DkCounter type)
+	{
+		return ::dkCmdBufResetCounter(*this, type);
 	}
 
 	inline Queue QueueMaker::create() const

--- a/include/deko3d.hpp
+++ b/include/deko3d.hpp
@@ -149,6 +149,8 @@ namespace dk
 	struct Device : public detail::Handle<::DkDevice>
 	{
 		DK_HANDLE_COMMON_MEMBERS(Device);
+		uint64_t getCurrentTimestamp();
+		uint64_t getCurrentTimestampInNs();
 	};
 
 	struct MemBlock : public detail::Handle<::DkMemBlock>
@@ -566,6 +568,16 @@ namespace dk
 	{
 		::dkDeviceDestroy(*this);
 		_clear();
+	}
+
+	inline uint64_t Device::getCurrentTimestamp()
+	{
+		return ::dkDeviceGetCurrentTimestamp(*this);
+	}
+
+	inline uint64_t Device::getCurrentTimestampInNs()
+	{
+		return ::dkDeviceGetCurrentTimestampInNs(*this);
 	}
 
 	inline MemBlock MemBlockMaker::create() const

--- a/source/dk_device.cpp
+++ b/source/dk_device.cpp
@@ -257,3 +257,13 @@ void ObjBase::freeMem(void* mem) const noexcept
 {
 	return m_device->freeMem(mem);
 }
+
+uint64_t dkDeviceGetCurrentTimestamp([[maybe_unused]] DkDevice obj) {
+	u64 ts;
+	Result rc = nvGpuGetTimestamp(&ts);
+	return R_SUCCEEDED(rc) ? ts : 0;
+}
+
+uint64_t dkDeviceGetCurrentTimestampInNs(DkDevice obj) {
+	return dkTimestampToNs(dkDeviceGetCurrentTimestamp(obj));
+}

--- a/source/maxwell/engine_3d.def
+++ b/source/maxwell/engine_3d.def
@@ -459,6 +459,24 @@ engine _3D 0xB197;
 
 0x54A SetShaderExceptions bool;
 
+0x54C ResetCounter enum (
+	0x01 SamplesPassed;
+	0x02 ZcullStats;
+	0x10 TransformFeedbackPrimitivesWritten;
+	0x12 InputVertices;
+	0x13 InputPrimitives;
+	0x15 VertexShaderInvocations;
+	0x16 TessControlShaderInvocations;
+	0x17 TessEvaluationShaderInvocations;
+	0x18 TessEvaluationShaderPrimitives;
+	0x1A GeometryShaderInvocations;
+	0x1B GeometryShaderPrimitives;
+	0x1C ClipperInputPrimitives;
+	0x1D ClipperOutputPrimitives;
+	0x1E FragmentShaderInvocations;
+	0x1F PrimitivesGenerated;
+);
+
 0x54D MultisampleEnable bool;
 0x54E DepthTargetEnable bool;
 0x54F MultisampleControl bits (
@@ -646,7 +664,7 @@ engine _3D 0xB197;
 	0..1 Operation enum (
 		0 Release;
 		1 Acquire;
-		2 Unknown;
+		2 Counter;
 		3 Trap;
 	);
 	2 FlushDisable;
@@ -669,6 +687,8 @@ engine _3D 0xB197;
 		5 StrmOut;
 		6 GP;
 		7 ZCull;
+		8 TessCtrl;
+		9 TessEval;
 		10 Prop;
 		15 Crop;
 	);
@@ -681,6 +701,28 @@ engine _3D 0xB197;
 		1 Signed32;
 	);
 	20 AwakenEnable;
+	23..27 Counter enum (
+		0x00 Payload;
+		0x01 InputVertices;
+		0x03 InputPrimitives;
+		0x05 VertexShaderInvocations;
+		0x07 GeometryShaderInvocations;
+		0x09 GeometryShaderPrimitives;
+		0x0A ZcullStats0;
+		0x0B TransformFeedbackPrimitivesWritten;
+		0x0C ZcullStats1;
+		0x0E ZcullStats2;
+		0x0F ClipperInputPrimitives;
+		0x10 ZcullStats3;
+		0x11 ClipperOutputPrimitives;
+		0x12 PrimitivesGenerated;
+		0x13 FragmentShaderInvocations;
+		0x15 SamplesPassed;
+		0x1A TransformFeedbackOffset;
+		0x1B TessControlShaderInvocations;
+		0x1D TessEvaluationShaderInvocations;
+		0x1F TessEvaluationShaderPrimitives;
+	);
 	28 StructureSize enum (
 		0 FourWords;
 		1 OneWord;


### PR DESCRIPTION
This is essentially a reimplementation of `nvnCommandBufferReportCounter` etc, and `nvnDeviceGetCurrentTimestampInNanoseconds` etc.
Names were taken from Ryujinx for the most part, and cross-referenced with envytools when possible.

A note: in the command header for `DkCounter_TimestampPipelineTop`, official software uses subchannel id 0 (3D), but I used GpFifo to be able to use the `Cmd` macro. I think in that case they are equivalent anyways.

Edit: also the timestamp stuff depends on https://github.com/switchbrew/libnx/pull/591