### PR TITLE
dkCmdBufPushConstants: check for pushbuffer overflow

### DIFF
--- a/source/maxwell/gpu_base.cpp
+++ b/source/maxwell/gpu_base.cpp
@@ -148,6 +148,7 @@ void dkCmdBufPushConstants(DkCmdBuf obj, DkGpuAddr uboAddr, uint32_t uboSize, ui
 	DK_DEBUG_BAD_INPUT(uboSize > DK_UNIFORM_BUF_MAX_SIZE);
 	DK_DEBUG_DATA_ALIGN(offset, 4);
 	DK_DEBUG_SIZE_ALIGN(size, 4);
+	DK_DEBUG_BAD_INPUT(size > 0x7FFC);
 	DK_DEBUG_BAD_INPUT((offset >= uboSize) || (size > uboSize));
 	DK_DEBUG_BAD_INPUT((offset + size) > uboSize);
 	DK_DEBUG_NON_NULL(data);


### PR DESCRIPTION
This reproduces the check in dkCmdBufPushData, otherwise the pushbuffer entry exceeds the maximum size permitted by the bitfield in the method header.

<details><summary>Test program</summary>
<p>

```c
#include <stdio.h>
#include <stdlib.h>
#include <string.h>

#include <switch.h>
#include <deko3d.h>

void userAppInit(void) {
    socketInitializeDefault();
    nxlinkStdio();
}

void userAppExit() {
    socketExit();
}

int main(int argc, char* argv[]) {
    DkDeviceMaker deviceMaker;
    dkDeviceMakerDefaults(&deviceMaker);
    DkDevice device = dkDeviceCreate(&deviceMaker);

    DkQueueMaker queue_maker;
    dkQueueMakerDefaults(&queue_maker, device);
    DkQueue queue = dkQueueCreate(&queue_maker);

    DkMemBlockMaker memblock_maker;
    dkMemBlockMakerDefaults(&memblock_maker, device, DK_UNIFORM_BUF_MAX_SIZE);
    memblock_maker.flags = DkMemBlockFlags_CpuUncached | DkMemBlockFlags_GpuCached | DkMemBlockFlags_ZeroFillInit;

    DkMemBlock cmd_memblock = dkMemBlockCreate(&memblock_maker);

    DkCmdBufMaker cmdbuf_maker;
    dkCmdBufMakerDefaults(&cmdbuf_maker, device);
    DkCmdBuf cmdbuf = dkCmdBufCreate(&cmdbuf_maker);
    dkCmdBufAddMemory(cmdbuf, cmd_memblock,
        0, dkMemBlockGetSize(cmd_memblock));

    DkMemBlock memblock = dkMemBlockCreate(&memblock_maker);

    size_t copy_size = 0xA000;
    u8 *mem = malloc(copy_size);
    memset(mem, 0xCC, copy_size);

    dkCmdBufPushConstants(cmdbuf, dkMemBlockGetGpuAddr(memblock), dkMemBlockGetSize(memblock),
        0, copy_size, mem);
    dkQueueSubmitCommands(queue, dkCmdBufFinishList(cmdbuf));
    dkQueueWaitIdle(queue);

    assert(((u8 *)dkMemBlockGetCpuAddr(memblock))[0x8000] == 0xCC);

    free(mem);

    dkMemBlockDestroy(memblock);

    dkMemBlockDestroy(cmd_memblock);
    dkQueueDestroy(queue);
    dkDeviceDestroy(device);

    return 0;
}
```
</p>
</details> 

Result:
```
deko3d warning in dkCmdBufBarrier: Queue (0) entered error state
deko3d warning in dkCmdBufBarrier:   timestamp: 67275475420
deko3d warning in dkCmdBufBarrier:   info32: 32
deko3d warning in dkCmdBufBarrier:   info16: 0
deko3d warning in dkCmdBufBarrier:   status: 65535
deko3d warning in dkCmdBufBarrier:   --
deko3d warning in dkCmdBufBarrier:   GPU rejected command list
```
