### PR TITLE
Add helper to import an external fence

### DIFF
--- a/Primer.md
+++ b/Primer.md
@@ -327,11 +327,14 @@ Command lists can be reused by other command lists as well. When `dkCmdBufCallLi
 ```c
 struct DkFence;
 DkResult dkFenceWait(DkFence* obj, int64_t timeout_ns);
+DkFence dkFenceImport(uint32_t id, uint32_t value);
 ```
 
 Fences (`DkFence`) are opaque structs that contain GPU synchronization information, used to determine when work submitted to the GPU has finished executing. Each time they're scheduled to be signaled in a queue (`DkQueue`), either directly or indirectly through a command list, their contents are updated. Fences can be waited on by the GPU or CPU (using the `dkFenceWait` function). When a fence is waited on, the waiter (CPU or GPU) will be kept blocked until the point in which it's signaled (hence marking the completion of dependent work).
 
 Usually fences will be used in a signaling command prior to being waited on. If fences are to be potentially waited on before they're signaled (e.g. if they're used to wait on previous work, with no previous work having been submitted yet), they should be initialized to zero in order to ensure that any initial waits will correctly have no effect.
+
+Synchronization between the GPU and external engines (video processing, display, etc) can be achieved through the `dkFenceImport` function, which provides a way of integrating Host1x syncpoint functionality within deko3d. The `id` and `value` parameters respectively represent the syncpt index, and the threshold at which the work associated with the fence can be considered as completed. Note that syncpoints are usually allocated and managed by the driver. More information on syncpoints can be found in the Tegra TRM, chapter 14 ("Host Subsystem").
 
 > **Warning**: Fence wait/signal commands recorded to a command list keep a pointer to the fence struct in the command buffer's bookkeeping memory. Please make sure the struct remains at the same valid memory address for the lifetime of the command list handle; otherwise submitting the command list handle to a queue will result in undefined behavior.
 

--- a/Primer.md
+++ b/Primer.md
@@ -327,14 +327,14 @@ Command lists can be reused by other command lists as well. When `dkCmdBufCallLi
 ```c
 struct DkFence;
 DkResult dkFenceWait(DkFence* obj, int64_t timeout_ns);
-DkFence dkFenceImport(uint32_t id, uint32_t value);
+void dkFenceImport(DkFence* obj, uint32_t id, uint32_t value);
 ```
 
 Fences (`DkFence`) are opaque structs that contain GPU synchronization information, used to determine when work submitted to the GPU has finished executing. Each time they're scheduled to be signaled in a queue (`DkQueue`), either directly or indirectly through a command list, their contents are updated. Fences can be waited on by the GPU or CPU (using the `dkFenceWait` function). When a fence is waited on, the waiter (CPU or GPU) will be kept blocked until the point in which it's signaled (hence marking the completion of dependent work).
 
 Usually fences will be used in a signaling command prior to being waited on. If fences are to be potentially waited on before they're signaled (e.g. if they're used to wait on previous work, with no previous work having been submitted yet), they should be initialized to zero in order to ensure that any initial waits will correctly have no effect.
 
-Synchronization between the GPU and external engines (video processing, display, etc) can be achieved through the `dkFenceImport` function, which provides a way of integrating Host1x syncpoint functionality within deko3d. The `id` and `value` parameters respectively represent the syncpt index, and the threshold at which the work associated with the fence can be considered as completed. Note that syncpoints are usually allocated and managed by the driver. More information on syncpoints can be found in the Tegra TRM, chapter 14 ("Host Subsystem").
+Synchronization between the GPU and external engines (video processing, display, etc) can be achieved through the `dkFenceImport` function, which provides a way of integrating Host1x syncpoint functionality within deko3d. The `id` and `value` parameters respectively represent the syncpt index, and the threshold at which the work associated with the fence can be considered as completed. Note that those values are usually allocated and managed by the driver. More information on syncpoints can be found in the Tegra TRM, chapter 14 ("Host Subsystem").
 
 > **Warning**: Fence wait/signal commands recorded to a command list keep a pointer to the fence struct in the command buffer's bookkeeping memory. Please make sure the struct remains at the same valid memory address for the lifetime of the command list handle; otherwise submitting the command list handle to a queue will result in undefined behavior.
 

--- a/include/deko3d.h
+++ b/include/deko3d.h
@@ -1238,7 +1238,7 @@ uint32_t dkMemBlockGetSize(DkMemBlock obj);
 DkResult dkMemBlockFlushCpuCache(DkMemBlock obj, uint32_t offset, uint32_t size);
 
 DkResult dkFenceWait(DkFence* obj, int64_t timeout_ns);
-DkFence dkFenceImport(uint32_t id, uint32_t value);
+void dkFenceImport(DkFence* obj, uint32_t id, uint32_t value);
 
 void dkVariableInitialize(DkVariable* obj, DkMemBlock mem, uint32_t offset);
 uint32_t dkVariableRead(DkVariable const* obj);

--- a/include/deko3d.h
+++ b/include/deko3d.h
@@ -1238,6 +1238,7 @@ uint32_t dkMemBlockGetSize(DkMemBlock obj);
 DkResult dkMemBlockFlushCpuCache(DkMemBlock obj, uint32_t offset, uint32_t size);
 
 DkResult dkFenceWait(DkFence* obj, int64_t timeout_ns);
+DkFence dkFenceImport(uint32_t id, uint32_t value);
 
 void dkVariableInitialize(DkVariable* obj, DkMemBlock mem, uint32_t offset);
 uint32_t dkVariableRead(DkVariable const* obj);

--- a/include/deko3d.hpp
+++ b/include/deko3d.hpp
@@ -166,7 +166,7 @@ namespace dk
 	{
 		DK_OPAQUE_COMMON_MEMBERS(Fence);
 		DkResult wait(int64_t timeout_ns = -1);
-		static DkFence import(uint32_t id, uint32_t value);
+		void import(uint32_t id, uint32_t value);
 	};
 
 	struct Variable : public detail::Opaque<::DkVariable>
@@ -617,9 +617,9 @@ namespace dk
 		return ::dkFenceWait(this, timeout_ns);
 	}
 
-	inline DkFence Fence::import(uint32_t id, uint32_t value)
+	inline void Fence::import(uint32_t id, uint32_t value)
 	{
-		return ::dkFenceImport(id, value);
+		::dkFenceImport(this, id, value);
 	}
 
 	inline void Variable::initialize(DkMemBlock mem, uint32_t offset)

--- a/include/deko3d.hpp
+++ b/include/deko3d.hpp
@@ -166,6 +166,7 @@ namespace dk
 	{
 		DK_OPAQUE_COMMON_MEMBERS(Fence);
 		DkResult wait(int64_t timeout_ns = -1);
+		static DkFence import(uint32_t id, uint32_t value);
 	};
 
 	struct Variable : public detail::Opaque<::DkVariable>
@@ -614,6 +615,11 @@ namespace dk
 	inline DkResult Fence::wait(int64_t timeout_ns)
 	{
 		return ::dkFenceWait(this, timeout_ns);
+	}
+
+	inline DkFence Fence::import(uint32_t id, uint32_t value)
+	{
+		return ::dkFenceImport(id, value);
 	}
 
 	inline void Variable::initialize(DkMemBlock mem, uint32_t offset)

--- a/source/dk_fence.cpp
+++ b/source/dk_fence.cpp
@@ -70,10 +70,9 @@ DkResult dkFenceWait(DkFence* obj, int64_t timeout_ns)
 	return obj->wait(timeout_us);
 }
 
-DkFence dkFenceImport(uint32_t id, uint32_t value) {
-	DkFence fence;
-	fence.m_type = DkFence::External;
-	fence.m_external.m_fence = {
+void dkFenceImport(DkFence* obj, uint32_t id, uint32_t value) {
+	obj->m_type = DkFence::External;
+	obj->m_external.m_fence = {
 		.num_fences = 1,
 		.fences = {
 			{
@@ -82,5 +81,4 @@ DkFence dkFenceImport(uint32_t id, uint32_t value) {
 			},
 		},
 	};
-	return fence;
 }

--- a/source/dk_fence.cpp
+++ b/source/dk_fence.cpp
@@ -69,3 +69,18 @@ DkResult dkFenceWait(DkFence* obj, int64_t timeout_ns)
 		timeout_us = timeout_ns / 1000;
 	return obj->wait(timeout_us);
 }
+
+DkFence dkFenceImport(uint32_t id, uint32_t value) {
+	DkFence fence;
+	fence.m_type = DkFence::External;
+	fence.m_external.m_fence = {
+		.num_fences = 1,
+		.fences = {
+			{
+				.id    = id,
+				.value = value,
+			},
+		},
+	};
+	return fence;
+}


### PR DESCRIPTION
During hardware-accelerated video playback, in order to remove a synchronization roundtrip between the decode engine and the GPU, waiting on a Host1x syncpt from the GPU is necessary. 
Fortunately, deko3d already has such a mechanism for display sync, so we can simply reuse that code.