### PR TITLE
Fix default Y-axis direction

### DIFF
--- a/Primer.md
+++ b/Primer.md
@@ -68,7 +68,7 @@ In order to create a handle, a code section like the following will be used:
 // Describe the device we're about to make
 DkDeviceMaker maker;
 dkDeviceMakerDefaults(&maker);
-maker.flags = DkDeviceFlags_OriginLowerLeft;
+maker.flags = DkDeviceFlags_OriginLowerLeft | DkDeviceFlags_YAxisPointsUp;
 
 // Create the device
 DkDevice device = dkDeviceCreate(&maker);
@@ -79,7 +79,7 @@ DkDevice device = dkDeviceCreate(&maker);
 // Create the device in one go
 // In the C++ wrapper, Maker objects follow the factory pattern
 dk::Device device = dk::DeviceMaker{}
-	.setFlags(DkDeviceFlags_OriginLowerLeft)
+	.setFlags(DkDeviceFlags_OriginLowerLeft | DkDeviceFlags_YAxisPointsUp)
 	.create();
 ```
 
@@ -103,7 +103,7 @@ In C++, an additional series of handle holder types exist (marked with `Unique` 
 // Create the device
 // dk::UniqueDevice contains a destructor which will automatically call destroy()
 dk::UniqueDevice device = dk::DeviceMaker{}
-	.setFlags(DkDeviceFlags_OriginLowerLeft)
+	.setFlags(DkDeviceFlags_OriginLowerLeft | DkDeviceFlags_YAxisPointsUp)
 	.create();
 ```
 
@@ -203,8 +203,8 @@ Field      | Default   | Description
 `DepthMinusOneToOne` |         | Clip space Z is [-1, 1] like OpenGL
 `OriginUpperLeft`    | ✓       | Image rows are stored sequentially from top to bottom, with 0.0 corresponding to the top edge of the image and 1.0 (or the image height if non-normalized) corresponding to the bottom
 `OriginLowerLeft`    |         | Image rows are stored sequentially from bottom to top, with 0.0 corresponding to the bottom edge of the image and 1.0 (or the image height if non-normalized) corresponding to the top
-`YAxisPointsUp`      | ✓       | Clip space Y axis points up like OpenGL/Direct3D/Metal
-`YAxisPointsDown`    |         | Clip space Y axis points down like Vulkan
+`YAxisPointsUp`      |         | Clip space Y axis points up like OpenGL/Direct3D/Metal
+`YAxisPointsDown`    | ✓       | Clip space Y axis points down like Vulkan
 
 The debugging version of the library can use an optional callback (`cbDebug`). There are two situations in which deko3d makes usage of the debug callback:
 

--- a/include/deko3d.h
+++ b/include/deko3d.h
@@ -136,7 +136,7 @@ DK_CONSTEXPR void dkDeviceMakerDefaults(DkDeviceMaker* maker)
 	maker->cbDebug = NULL;
 	maker->cbAlloc = NULL;
 	maker->cbFree = NULL;
-	maker->flags = DkDeviceFlags_DepthZeroToOne | DkDeviceFlags_OriginUpperLeft;
+	maker->flags = DkDeviceFlags_DepthZeroToOne | DkDeviceFlags_OriginUpperLeft | DkDeviceFlags_YAxisPointsDown;
 }
 
 #define DK_MEMBLOCK_ALIGNMENT 0x1000


### PR DESCRIPTION
When compiling with the newest dkA64 release, most deko3d programs render incorrectly. After confirming the issue on a fresh dev environment, I believe the problem stems from a compiler bugfix.
<details>
  <summary>Screenshots</summary>

Simple triangle
![2025060312105900-CD8DDEDFE332FE055C049150B035121B](https://github.com/user-attachments/assets/d8f3f417-1763-4628-9bc5-aa08356b65e2)

Textured cube
![2025060312110500-CD8DDEDFE332FE055C049150B035121B](https://github.com/user-attachments/assets/d0d2cbce-4c53-47ca-b63d-8ef4bae15ebd)

Mesh loading and lighting
![2025060312111100-CD8DDEDFE332FE055C049150B035121B](https://github.com/user-attachments/assets/74cb8b86-3bfe-4904-97dc-c6a6db6dd016)

Deferred shading
![2025060312111700-CD8DDEDFE332FE055C049150B035121B](https://github.com/user-attachments/assets/1e33558d-b78d-4a88-9a3d-21993b9ed7c4)
</details>

Checking the code for `dkCmdBufSetViewports`, the deko3d version currently found in the pacman repos only checks `DkDeviceFlags_YAxisPointsDown`. The freshly compiled version checks for both this and `DkDeviceFlags_YAxisPointsDown`.
![image](https://github.com/user-attachments/assets/2c12f85f-73a8-4286-a501-a4fc0eb3871f)
![image](https://github.com/user-attachments/assets/3fb65287-f551-47f9-b563-9840519a8f95)

However to me the current default viewport settings don't make sense, as we have both an origin in the upper left and an Y-axis pointing up, and indeed forcing a downward Y-axis fixes the issues. In any case the code was implicitely relying on a compiler bug.
