### PR TITLE
fix viewportFlipY XOR condition

### DIFF
--- a/source/dk_device.h
+++ b/source/dk_device.h
@@ -99,7 +99,7 @@ public:
 
 	// Rasterizer expects clip space +Y to point down. In UpperLeft mode with Y pointing up
 	// (or LowerLeft mode with Y pointing down) we need to flip the incoming Y coordinate.
-	bool viewportFlipY() const noexcept { return !isYAxisPointsDown() ^ !isOriginLowerLeft(); }
+	bool viewportFlipY() const noexcept { return !(!isYAxisPointsDown() ^ !isOriginLowerLeft()); }
 
 	DkResult initialize() noexcept;
 	~Device();

--- a/source/dk_device.h
+++ b/source/dk_device.h
@@ -99,7 +99,7 @@ public:
 
 	// Rasterizer expects clip space +Y to point down. In UpperLeft mode with Y pointing up
 	// (or LowerLeft mode with Y pointing down) we need to flip the incoming Y coordinate.
-	bool viewportFlipY() const noexcept { return !(!isYAxisPointsDown() ^ !isOriginLowerLeft()); }
+	bool viewportFlipY() const noexcept { return isYAxisPointsDown() ^ !isOriginLowerLeft(); }
 
 	DkResult initialize() noexcept;
 	~Device();


### PR DESCRIPTION
## Motivation
https://github.com/devkitPro/deko3d/blob/8cb7b4c6fcf71881f024e9d50876914938d85053/source/dk_device.h#L100-L102
The implementation is not consistent with the comment. We intend to flip Y when `UpperLeft mode with Y pointing up`. But in this case, `!isYAxisPointsDown() = true` and `!isOriginLowerLeft() = true`,  `true ^ true = false`. Same as `LowerLeft mode with Y pointing down`.

## Key Change
The fix is simple, I think the comment is the correct logic, so just add a `!` before return.